### PR TITLE
apply cancelation after execution of async debounced function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,35 @@
 function debounce<T, A extends Array<unknown>>(fn: (...args: A) => Promise<T>, ms = 0) {
-  let timer: ReturnType<typeof setTimeout> | undefined = undefined
-  let cancelled = false
+	let lastTimer: ReturnType<typeof setTimeout> | undefined = undefined
+	let cancelled = false
 
-  const debounced = (...args: A) => {
-    cancelled = false
-    if (timer) {
-      clearTimeout(timer)
-    }
-    return new Promise<T>(resolve => {
-      timer = setTimeout(() => {
-        if (!cancelled) {
-          resolve(fn(...args))
-        }
-      }, ms)
-    })
-  }
+	const debounced = (...args: A) => {
+		cancelled = false
+		if (lastTimer) {
+			clearTimeout(lastTimer)
+		}
+		return new Promise<T>((resolve, reject) => {
+			const curTimer = setTimeout(async () => {
+				try {
+					let res;
+					if (!cancelled && curTimer === lastTimer) {
+						res = await fn(...args)
+					}
+					if (!cancelled && curTimer === lastTimer) {
+						resolve(res)
+					}
+				} catch (e) {
+					reject(e)
+				}
+			}, ms)
+			lastTimer = curTimer;
+		})
+	}
 
-  debounced.cancel = function() {
-    cancelled = true
-  }
+	debounced.cancel = function() {
+		cancelled = true
+	}
 
-  return debounced
+	return debounced
 }
 
 export default debounce

--- a/test/index.ts
+++ b/test/index.ts
@@ -45,3 +45,31 @@ it('should check if debounce fn can be cancelled', async () => {
   await pause(10)
   expect(callback).not.to.have.been.called
 })
+
+it('should check if debounce fn can be cancelled', async () => {
+  const asyncCallback = async (value:any) => {
+    await pause(10)
+  };
+  const resolved = spy()
+  const result = debounce(asyncCallback, 10)
+  result(1).then(resolved)
+  await pause(15)
+  result.cancel()
+  await pause(15)
+  expect(resolved).not.to.have.been.called
+})
+
+it('should check with async callback must be resolved only the last ', async () => {
+  const asyncCallback = async (value:any) => {
+    await pause(10)
+  };
+  const firstResolved = spy()
+  const lastResolved = spy()
+  const result = debounce(asyncCallback, 10)
+  result(1).then(firstResolved)
+  await pause(15)
+  result(2).then(lastResolved)
+  await pause(25)
+  expect(firstResolved).not.to.have.been.called
+  expect(lastResolved).to.have.been.called
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["es5", "es2017", "dom"], /* Specify library files to be included in the compilation. */
     "allowJs": false /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
Before if debounced function return promise, cancel didn't work, because it applied only to timer. Also with comparing the last and current timer we can be sure that only the last call will be resolved